### PR TITLE
Incorporated Stop Intent

### DIFF
--- a/brooklinevoiceapp/brookline_controller.py
+++ b/brooklinevoiceapp/brookline_controller.py
@@ -115,9 +115,30 @@ def on_intent(mycity_request):
             return find_closest_library(mycity_request)
         elif mycity_request.intent_name == "AMAZON.FallbackIntent":
             return get_fallback_intent_response(mycity_request)
+        elif mycity_request.intent_name == "AMAZON.StopIntent":
+            return handle_session_end_request(mycity_request)
         else:
             raise ValueError("Invalid Intent")
     except BaseOutputSpeechError as e:
         response = on_session_ended(mycity_request)
         response.output_speech = e.output_speech
         return response
+
+
+def handle_session_end_request(mycity_request):
+    """
+    Ends a user's session (with the Brookline Info skill).
+    Called when request intent is AMAZON.StopIntent.
+
+    :param mycity_request: MyCityRequestDataModel object
+    :return: MyCityResponseDataModel object that will end a user's session
+    """
+    logger.debug('Closing')
+    mycity_response = MyCityResponseDataModel()
+    mycity_response.session_attributes = mycity_request.session_attributes
+    mycity_response.card_title = "Brookline Info - Thanks"
+    mycity_response.output_speech = \
+        "Thank you for using the Brookline Info skill. " \
+        "See you next time!"
+    mycity_response.should_end_session = True
+    return mycity_response

--- a/brooklinevoiceapp/mycity/test/unit_tests/test_brookline_controller.py
+++ b/brooklinevoiceapp/mycity/test/unit_tests/test_brookline_controller.py
@@ -1,0 +1,27 @@
+"""
+unit test for BrooklineController
+"""
+
+import brookline_controller as bl_con
+import mycity.test.unit_tests.base as base
+
+
+class BrooklineControllerUnitTestCase(base.BaseTestCase):
+    """
+    testing:
+        handle_session_end_request
+    """
+
+    def test_on_intent_AMAZON_StopIntent(self):
+        expected_attributes = self.request.session_attributes
+        expected_output_speech = (
+            "Thank you for using the Brookline Info skill. "
+            "See you next time!"
+        )
+        expected_card_title = "Brookline Info - Thanks"
+        self.request.intent_name = "AMAZON.StopIntent"
+        response = self.controller.on_intent(self.request)
+        self.assertEqual(response.session_attributes, expected_attributes)
+        self.assertEqual(response.output_speech, expected_output_speech)
+        self.assertEqual(response.card_title, expected_card_title)
+        self.assertIsNone(response.reprompt_text)


### PR DESCRIPTION
I created the Stop Intent for the voice app to address #45 with the `handle_session_end_request` function in the `brookline_controller.py` file.  I also address a bit of #20 to test the stop intent in `test_brookline_controller.py` and hopefully allow full testing of the controller in the near future. Let me know if there is something else to address in the Stop Intent.