### PR TITLE
Fill more of test_brookline_controller

### DIFF
--- a/brooklinevoiceapp/brookline_controller.py
+++ b/brooklinevoiceapp/brookline_controller.py
@@ -14,6 +14,11 @@ from mycity.utils.exceptions import BaseOutputSpeechError
 logger = logging.getLogger(__name__)
 
 
+LAUNCH_SPEECH = "Welcome to the Brookline Info skill. How can I help you?"
+LAUNCH_REPROMPT_SPEECH = "You can ask about the nearest city services."
+NO_REQUEST_SPEECH = "Hello from Brookline! We do not support that yet"
+
+
 def execute_request(mycity_request):
     """
     Executes a request to the town of Brookline available intents
@@ -32,7 +37,7 @@ def execute_request(mycity_request):
         response = on_session_ended(mycity_request)
     else:
         response = MyCityResponseDataModel()
-        response.output_speech = "Hello from Brookline! We do not support that yet"
+        response.output_speech = NO_REQUEST_SPEECH
 
     response.session_attributes = mycity_request.session_attributes
     return response
@@ -69,14 +74,12 @@ def get_welcome_response(mycity_request):
     mycity_response = MyCityResponseDataModel()
     mycity_response.session_attributes = mycity_request.session_attributes
     mycity_response.card_title = "Welcome"
-    mycity_response.output_speech = \
-        "Welcome to the Brookline Info skill. How can I help you? "
+    mycity_response.output_speech = LAUNCH_SPEECH
 
     # If the user either does not reply to the welcome message or says
     # something that is not understood, they will be prompted again with
     # this text.
-    mycity_response.reprompt_text = \
-        "You can ask about the nearest city services."
+    mycity_response.reprompt_text = LAUNCH_REPROMPT_SPEECH
     mycity_response.should_end_session = False
     return mycity_response
 

--- a/brooklinevoiceapp/mycity/test/unit_tests/test_brookline_controller.py
+++ b/brooklinevoiceapp/mycity/test/unit_tests/test_brookline_controller.py
@@ -3,14 +3,41 @@ unit test for BrooklineController
 """
 
 import brookline_controller as bl_con
+import mycity.intents.intent_constants as intent_constants
 import mycity.test.unit_tests.base as base
 
 
 class BrooklineControllerUnitTestCase(base.BaseTestCase):
     """
     testing:
+        execute_request
+        on_intent
+        get_welcome_response
         handle_session_end_request
     """
+
+    def test_welcome_response(self):
+        self.request.is_new_session = False
+        self.request.request_type = "LaunchRequest"
+        expected_session_attributes = self.request.session_attributes
+        expected_output_speech = bl_con.LAUNCH_SPEECH
+        expected_reprompt_text = bl_con.LAUNCH_REPROMPT_SPEECH
+        expected_card_title = "Welcome"
+        response = self.controller.execute_request(self.request)
+        self.assertEqual(
+            response.session_attributes,
+            expected_session_attributes
+        )
+        self.assertEqual(response.output_speech, expected_output_speech)
+        self.assertEqual(response.reprompt_text, expected_reprompt_text)
+        self.assertFalse(response.should_end_session)
+
+    def test_execute_request_with_no_request_speech(self):
+        self.request.is_new_session = False
+        self.request.request_type = None
+        expected_output_speech = bl_con.NO_REQUEST_SPEECH
+        response = self.controller.execute_request(self.request)
+        self.assertEqual(response.output_speech, expected_output_speech)
 
     def test_on_intent_AMAZON_StopIntent(self):
         expected_attributes = self.request.session_attributes
@@ -19,9 +46,16 @@ class BrooklineControllerUnitTestCase(base.BaseTestCase):
             "See you next time!"
         )
         expected_card_title = "Brookline Info - Thanks"
+        self.request.request_type = "IntentRequest"
         self.request.intent_name = "AMAZON.StopIntent"
-        response = self.controller.on_intent(self.request)
+        response = self.controller.execute_request(self.request)
         self.assertEqual(response.session_attributes, expected_attributes)
         self.assertEqual(response.output_speech, expected_output_speech)
         self.assertEqual(response.card_title, expected_card_title)
         self.assertIsNone(response.reprompt_text)
+
+    def test_unknown_intent(self):
+        self.request.intent_name = "MadeUpIntent"
+        self.request.session_attributes[intent_constants.CURRENT_ADDRESS_KEY] = '46 Everdean St'
+        with self.assertRaises(ValueError):
+            self.controller.on_intent(self.request)


### PR DESCRIPTION
I filled in a bit more of the Brookline Controller test to help address #20 with much of what I can try to cover the brookline_controller.py. My concern right now is that is the current set of tests is sufficient enough? And this is where I hope I can try to resolve with incorporating code coverage with trying to get codecov in Travis CI working. 

The thing in particular that I am concerned about is `on_session_started` and `on_session_ended` not being called at all and I am unsure if that is something that should be included in the test.

Other than that, let me know if there are other things I should address for the controller test in particular. One other change is moving all of the output_speech into a constant variable for the module so testing could be more easily be operable, but let me know if you approve of this change or not.