### PR TITLE
Coveage over .travis.yml, run_tests.sh, and dev_requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ python:
   - "3.7"
 
 install:
+  - pip install -U pip
   - pip install -r requirements.txt
+  - pip install -r dev_requirements.txt
+  - pip install codecov
 
 script:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)

--- a/brooklinevoiceapp/run_tests.sh
+++ b/brooklinevoiceapp/run_tests.sh
@@ -1,17 +1,27 @@
 #!/usr/bin/env sh
+
+# Test if 'coverage' command exists
 if command -v coverage
 then
+    # test w/ coverage
     python -m coverage run --source='.' -m unittest discover -v -s mycity/test
 
+    # if exit code is 0, test is success and continue on, else exit w/ code
     if [ $? -eq 0 ]
     then
+        # test if 'codecov' in TravisCI exists
         if command -v codecov
         then
+            # move .coverage report file to root
             mv .coverage ..
         else
+            # just show coverage report for local
             python -m coverage report -m
         fi
+    else
+        exit $?
     fi
 else
+    # run the old command
     python -m unittest discover -v -s mycity/test
 fi

--- a/brooklinevoiceapp/run_tests.sh
+++ b/brooklinevoiceapp/run_tests.sh
@@ -1,2 +1,17 @@
 #!/usr/bin/env sh
-python -m unittest discover -v -s mycity/test
+if command -v coverage
+then
+    python -m coverage run --source='.' -m unittest discover -v -s mycity/test
+
+    if [ $? -eq 0 ]
+    then
+        if command -v codecov
+        then
+            mv .coverage ..
+        else
+            python -m coverage report -m
+        fi
+    fi
+else
+    python -m unittest discover -v -s mycity/test
+fi

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,2 @@
+awscli
+coverage


### PR DESCRIPTION
I got around setting up the code coverage CI build (for issue #49) in a way to help make testing all functions of the program a lot easier (such as trying to fill much of addressing issue #20). I implemented the `run_tests.sh` file in a way where only installing the packages from `requirements.txt` will work like normal to just test w/o showing coverage, but if you also install `coverage` from `pip` (or from `dev_requirements.txt`) it will show the coverage result locally if the test is successful. And only for Travis CI, if the test is successful, it sets up to upload the `.coverage` report file to codecov.io for you to see the code coverage result.

Let me know if this is suitable or there needs some modifications.